### PR TITLE
Refactoring RPC call / processing structure

### DIFF
--- a/src/raft/candidate.go
+++ b/src/raft/candidate.go
@@ -2,6 +2,24 @@ package raft
 
 import "fmt"
 
+type RequestVoteArgs struct {
+	Term        int // Candidate's Term
+	CandidateId int // ID of candidate requesting vote
+}
+
+func (args *RequestVoteArgs) String() string {
+	return fmt.Sprintf("C%d, T%d", args.CandidateId, args.Term)
+}
+
+type RequestVoteReply struct {
+	Term        int  // Current Term of server - for candidate to update itself
+	VoteGranted bool // Reply on whether candidate was granted vote
+}
+
+func (r *RequestVoteReply) String() string {
+	return fmt.Sprintf("T%d, %v", r.Term, r.VoteGranted)
+}
+
 type Candidate struct {
 	rf    *Raft
 	votes []bool
@@ -19,22 +37,22 @@ func (c *Candidate) startElection() {
 	c.rf.votedFor = c.rf.me
 
 	DPrintf(c.rf.me, cmpCandidate, "Calling for election @T%d", c.rf.currentTerm)
-	for i := range c.rf.peers {
-		if i == c.rf.me {
+	for peerId, peer := range c.rf.peers {
+		if peerId == c.rf.me {
 			continue
 		}
 
-		go c.rf.requestVote(i, c.rf.currentTerm, c.rf.me)
+		go peer.callRequestVote(c.rf.currentTerm, c.rf.me)
 	}
 }
 
-func (c *Candidate) electionTimeoutElapsed() ServerState {
+func (c *Candidate) processElectionTimeout() ServerStateMachine {
 	DPrintf(c.rf.me, cmpCandidate, "Election Timeout @ T%d. Starting new election.", c.rf.currentTerm)
 	c.startElection()
 	return c
 }
 
-func (c *Candidate) requestVoteReceived(args *RequestVoteArgs, reply *RequestVoteReply) ServerState {
+func (c *Candidate) processIncomingRequestVote(args *RequestVoteArgs, reply *RequestVoteReply) ServerStateMachine {
 	DPrintf(c.rf.me, cmpCandidate, "Denying RequestVote from S%d@T%d. Trying to win election.",
 		args.CandidateId, args.Term)
 
@@ -44,7 +62,11 @@ func (c *Candidate) requestVoteReceived(args *RequestVoteArgs, reply *RequestVot
 	return c
 }
 
-func (c *Candidate) voteResponseReceived(serverId int, args *RequestVoteArgs, reply *RequestVoteReply) ServerState {
+func (c *Candidate) shouldRetryFailedRequestVote(args *RequestVoteArgs) bool {
+	return c.rf.currentTerm == args.Term
+}
+
+func (c *Candidate) processRequestVoteResponse(serverId int, args *RequestVoteArgs, reply *RequestVoteReply) ServerStateMachine {
 	if args.Term < c.rf.currentTerm {
 		DPrintf(c.rf.me, cmpCandidate, "Received stale vote S%d @T%d < S%d@T%d. Ignoring.",
 			args.CandidateId, args.Term, c.rf.me, c.rf.currentTerm)
@@ -52,7 +74,7 @@ func (c *Candidate) voteResponseReceived(serverId int, args *RequestVoteArgs, re
 	}
 
 	if args.Term != c.rf.currentTerm || c.rf.currentTerm != reply.Term {
-		panic(fmt.Sprintf("Candidate voteResponseReceived, expected terms to all match, currentTerm: %d, argsTerm: %d, reply: %d",
+		panic(fmt.Sprintf("Candidate processRequestVoteResponse, expected terms to all match, currentTerm: %d, argsTerm: %d, reply: %d",
 			c.rf.currentTerm, args.Term, reply.Term))
 	}
 
@@ -82,15 +104,24 @@ func (c *Candidate) voteResponseReceived(serverId int, args *RequestVoteArgs, re
 	return c
 }
 
-func (c *Candidate) appendEntriesReceived(args *AppendEntriesArgs, reply *AppendEntriesReply) ServerState {
+func (c *Candidate) processIncomingAppendEntries(args *AppendEntriesArgs, reply *AppendEntriesReply) ServerStateMachine {
 	DPrintf(c.rf.me, cmpCandidate, "AppendEntries received from new Leader L%d@T%d. Converting to follower.",
 		args.LeaderId, args.Term)
 
 	f := &Follower{rf: c.rf}
-	f.appendEntriesReceived(args, reply)
+	f.processIncomingAppendEntries(args, reply)
 	return f
 }
 
-func (c *Candidate) shouldRetryRequestVote(args *RequestVoteArgs) bool {
-	return c.rf.currentTerm == args.Term
+func (c *Candidate) shouldRetryFailedAppendEntries(_ *AppendEntriesArgs) bool {
+	return false
+}
+
+func (c *Candidate) processAppendEntriesResponse(
+	_ int,
+	_ *AppendEntriesArgs,
+	_ *AppendEntriesReply) ServerStateMachine {
+
+	DPrintf(c.rf.me, cmpCandidate, "Received Stale AppendEntries Response. Ignoring.")
+	return c
 }

--- a/src/raft/config.go
+++ b/src/raft/config.go
@@ -632,7 +632,7 @@ func (cfg *config) end() {
 	if cfg.t.Failed() == false {
 		cfg.mu.Lock()
 		t := time.Since(cfg.t0).Seconds()       // real time
-		npeers := cfg.n                         // number of Raft peers
+		npeers := cfg.n                         // number of Raft peerClients
 		nrpc := cfg.rpcTotal() - cfg.rpcs0      // number of RPC sends
 		nbytes := cfg.bytesTotal() - cfg.bytes0 // number of bytes
 		ncmds := cfg.maxIndex - cfg.maxIndex0   // number of Raft agreements reported

--- a/src/raft/follower.go
+++ b/src/raft/follower.go
@@ -8,7 +8,7 @@ func (f *Follower) isLeader() bool {
 	return false
 }
 
-func (f *Follower) electionTimeoutElapsed() ServerState {
+func (f *Follower) processElectionTimeout() ServerStateMachine {
 	DPrintf(f.rf.me, cmpFollower, "Converting to Candidate")
 
 	candidate := &Candidate{rf: f.rf}
@@ -17,7 +17,7 @@ func (f *Follower) electionTimeoutElapsed() ServerState {
 	return candidate
 }
 
-func (f *Follower) requestVoteReceived(args *RequestVoteArgs, reply *RequestVoteReply) ServerState {
+func (f *Follower) processIncomingRequestVote(args *RequestVoteArgs, reply *RequestVoteReply) ServerStateMachine {
 	DPrintf(f.rf.me, cmpFollower, "Vote Requested from C%d@T%d", args.CandidateId, args.Term)
 
 	if f.rf.currentTerm > args.Term {
@@ -45,12 +45,16 @@ func (f *Follower) requestVoteReceived(args *RequestVoteArgs, reply *RequestVote
 	return f
 }
 
-func (f *Follower) voteResponseReceived(serverId int, args *RequestVoteArgs, reply *RequestVoteReply) ServerState {
+func (f *Follower) shouldRetryFailedRequestVote(_ *RequestVoteArgs) bool {
+	return false
+}
+
+func (f *Follower) processRequestVoteResponse(serverId int, args *RequestVoteArgs, _ *RequestVoteReply) ServerStateMachine {
 	DPrintf(f.rf.me, cmpFollower, "<~~~ S%d Stale Response to RequestVote(%v). Ignoring", serverId, args)
 	return f
 }
 
-func (f *Follower) appendEntriesReceived(args *AppendEntriesArgs, reply *AppendEntriesReply) ServerState {
+func (f *Follower) processIncomingAppendEntries(args *AppendEntriesArgs, reply *AppendEntriesReply) ServerStateMachine {
 	if f.rf.currentTerm > args.Term {
 		DPrintf(f.rf.me, cmpFollower, "AppendEntries from S%d@T%d < S%d@T%d. Replying false.",
 			args.LeaderId, args.Term, f.rf.me, f.rf.currentTerm)
@@ -65,6 +69,15 @@ func (f *Follower) appendEntriesReceived(args *AppendEntriesArgs, reply *AppendE
 	return f
 }
 
-func (f *Follower) shouldRetryRequestVote(args *RequestVoteArgs) bool {
+func (f *Follower) shouldRetryFailedAppendEntries(_ *AppendEntriesArgs) bool {
 	return false
+}
+
+func (f *Follower) processAppendEntriesResponse(
+	_ int,
+	_ *AppendEntriesArgs,
+	_ *AppendEntriesReply) ServerStateMachine {
+
+	DPrintf(f.rf.me, cmpCandidate, "Received Stale AppendEntries Response. Ignoring.")
+	return f
 }

--- a/src/raft/peer.go
+++ b/src/raft/peer.go
@@ -1,0 +1,49 @@
+package raft
+
+import (
+	"6.824/labrpc"
+)
+
+type Peer struct {
+	raft     *Raft
+	endPoint *labrpc.ClientEnd
+	serverId int
+}
+
+func (p *Peer) callRequestVote(term int, candidate int) {
+	args := &RequestVoteArgs{Term: term, CandidateId: candidate}
+	reply := &RequestVoteReply{}
+
+	DPrintf(p.raft.me, cmpRPC, "=-=> S%d Send RequestVote(%v)", p.serverId, args)
+	for !p.endPoint.Call("Raft.RequestVote", args, reply) {
+		DPrintf(p.raft.me, cmpRPC, "=/=> S%d Failed RequestVote()", p.serverId)
+
+		if p.raft.shouldRetryRequestVote(args) {
+			DPrintf(p.raft.me, cmpRPC, "=~=> S%d Retrying RequestVote())", p.serverId)
+		} else {
+			DPrintf(p.raft.me, cmpRPC, "=/=> S%d Dropping RequestVote()", p)
+			return
+		}
+	}
+
+	p.raft.dispatchRequestVoteResponse(p, args, reply)
+}
+
+func (p *Peer) callAppendEntries(leaderId int, term int) {
+	args := &AppendEntriesArgs{LeaderId: leaderId, Term: term}
+	reply := &AppendEntriesReply{}
+
+	DPrintf(p.raft.me, cmpRPC, "=-=> S%d Send AppendEntries(%v)", p.serverId, args)
+	for !p.endPoint.Call("Raft.AppendEntries", args, reply) {
+		DPrintf(p.raft.me, cmpRPC, "=/=> S%d Failed AppendEntries()", p.serverId)
+
+		if p.raft.shouldRetryFailedAppendEntries(args) {
+			DPrintf(p.raft.me, cmpRPC, "=~=> S%d Retrying AppendEntries())", p.serverId)
+		} else {
+			DPrintf(p.raft.me, cmpRPC, "=/=> S%d Dropping AppendEntries()", p)
+			return
+		}
+	}
+
+	p.raft.dispatchAppendEntriesResponse(p, args, reply)
+}

--- a/src/raft/snapshot.go
+++ b/src/raft/snapshot.go
@@ -1,0 +1,21 @@
+package raft
+
+//
+// A service wants to switch to snapshot.  Only do so if Raft hasn't
+// had more recent info since it communicate the snapshot on applyCh.
+//
+func (rf *Raft) CondInstallSnapshot(lastIncludedTerm int, lastIncludedIndex int, snapshot []byte) bool {
+
+	// Your code here (2D).
+
+	return true
+}
+
+// the service says it has created a snapshot that has
+// all info up to and including index. this means the
+// service no longer needs the log through (and including)
+// that index. Raft should now trim its log as much as possible.
+func (rf *Raft) Snapshot(index int, snapshot []byte) {
+	// Your code here (2D).
+
+}

--- a/src/raft/test_test.go
+++ b/src/raft/test_test.go
@@ -30,7 +30,7 @@ func TestInitialElection2A(t *testing.T) {
 	cfg.checkOneLeader()
 
 	// sleep a bit to avoid racing with followers learning of the
-	// election, then check that all peers agree on the term.
+	// election, then check that all peerClients agree on the term.
 	time.Sleep(50 * time.Millisecond)
 	term1 := cfg.checkTerms()
 	if term1 < 1 {
@@ -415,7 +415,7 @@ loop:
 			cmd := cfg.wait(index, servers, term)
 			if ix, ok := cmd.(int); ok {
 				if ix == -1 {
-					// peers have moved on to later terms
+					// peerClients have moved on to later terms
 					// so we can't expect all Start()s to
 					// have succeeded
 					failed = true
@@ -1041,7 +1041,7 @@ func internalChurn(t *testing.T, unreliable bool) {
 			}
 		}
 
-		// Make crash/restart infrequent enough that the peers can often
+		// Make crash/restart infrequent enough that the peerClients can often
 		// keep up, but not so infrequent that everything has settled
 		// down from one change to the next. Pick a value smaller than
 		// the election timeout, but not hugely smaller.

--- a/src/raft/util.go
+++ b/src/raft/util.go
@@ -6,7 +6,7 @@ import (
 )
 
 var debug = false
-var indent = false
+var indent = true
 
 func init() {
 	//debugVerbosity = getVerbosity()


### PR DESCRIPTION
Move the logic for calling RPCs and looping for retrying failed calls to a new structure called Peer that represents a single raft peer. Peer will delegate to Raft object to check if retries should occur and to process the result.

Raft object is the central point where the RPC request and response events come into from Peer or remote raft node. Calls are than dispatched to the current state (Candidate, Follower, Leader) handlers. This includes retry logic for failed RPC calls and processing of results.

Centralizing the dispatching structures all mutex locking into the Raft object all calls to checkTerm when receiving an RPC request or response.

The state machines (Candidate, Follower, Leader) now only include logic for processing events and do not contains RPC plumbing and term check logic.