### PR TITLE
Refactor log replication

### DIFF
--- a/src/raft/candidate.go
+++ b/src/raft/candidate.go
@@ -3,10 +3,10 @@ package raft
 import "fmt"
 
 type RequestVoteArgs struct {
-	Term         int // Candidate's Term
-	CandidateId  int // ID of candidate requesting vote
-	LastLogIndex int // index of Candidate's last log entry
-	LastLogTerm  int // term of Candidate's last log entry
+	Term         Term     // Candidate's Term
+	CandidateId  ServerId // ID of candidate requesting vote
+	LastLogIndex LogIndex // index of Candidate's last log entry
+	LastLogTerm  Term     // term of Candidate's last log entry
 }
 
 func (args *RequestVoteArgs) String() string {
@@ -14,7 +14,7 @@ func (args *RequestVoteArgs) String() string {
 }
 
 type RequestVoteReply struct {
-	Term        int  // Current Term of server - for candidate to update itself
+	Term        Term // Current Term of server - for candidate to update itself
 	VoteGranted bool // Reply on whether candidate was granted vote
 }
 
@@ -40,6 +40,7 @@ func (c *Candidate) startElection() {
 
 	DPrintf(c.rf.me, cmpCandidate, "running a campaign(T=%d)", c.rf.currentTerm)
 	for peerId, peer := range c.rf.peers {
+		peerId := ServerId(peerId)
 		if peerId == c.rf.me {
 			continue
 		}
@@ -69,7 +70,7 @@ func (c *Candidate) processIncomingRequestVote(args *RequestVoteArgs, reply *Req
 	return c
 }
 
-func (c *Candidate) processRequestVoteResponse(serverId int, args *RequestVoteArgs, reply *RequestVoteReply) ServerStateMachine {
+func (c *Candidate) processRequestVoteResponse(serverId ServerId, args *RequestVoteArgs, reply *RequestVoteReply) ServerStateMachine {
 	if args.Term < c.rf.currentTerm {
 		DPrintf(c.rf.me, cmpCandidate, "Received stale vote S%d @T%d < S%d@T%d. Ignoring.",
 			args.CandidateId, args.Term, c.rf.me, c.rf.currentTerm)
@@ -116,7 +117,7 @@ func (c *Candidate) processIncomingAppendEntries(args *AppendEntriesArgs, reply 
 }
 
 func (c *Candidate) processAppendEntriesResponse(
-	_ int,
+	_ ServerId,
 	_ *AppendEntriesArgs,
 	_ *AppendEntriesReply) ServerStateMachine {
 
@@ -124,6 +125,6 @@ func (c *Candidate) processAppendEntriesResponse(
 	return c
 }
 
-func (c *Candidate) processCommand(command interface{}) (index int, term int) {
+func (c *Candidate) processCommand(command interface{}) (index LogIndex, term Term) {
 	panic("Candidate should not be processing commands!")
 }

--- a/src/raft/follower.go
+++ b/src/raft/follower.go
@@ -55,7 +55,7 @@ func (f *Follower) processIncomingRequestVote(args *RequestVoteArgs, reply *Requ
 	return f
 }
 
-func (f *Follower) processRequestVoteResponse(serverId int, args *RequestVoteArgs, _ *RequestVoteReply) ServerStateMachine {
+func (f *Follower) processRequestVoteResponse(serverId ServerId, args *RequestVoteArgs, _ *RequestVoteReply) ServerStateMachine {
 	DPrintf(f.rf.me, cmpFollower, "<~~~ S%d Stale Response to RequestVote(%v). Ignoring", serverId, args)
 	return f
 }
@@ -88,7 +88,7 @@ func (f *Follower) processIncomingAppendEntries(args *AppendEntriesArgs, reply *
 
 	// Check 5 - Update Commit Index
 	if f.rf.commitIndex < args.LeaderCommit {
-		var maxEntry = 0
+		var maxEntry LogIndex = 0
 		if len(args.Entries) == 0 {
 			maxEntry = args.PrevLogIndex
 		} else {
@@ -113,7 +113,7 @@ func (f *Follower) processIncomingAppendEntries(args *AppendEntriesArgs, reply *
 }
 
 func (f *Follower) processAppendEntriesResponse(
-	_ int,
+	_ ServerId,
 	_ *AppendEntriesArgs,
 	_ *AppendEntriesReply) ServerStateMachine {
 
@@ -121,6 +121,6 @@ func (f *Follower) processAppendEntriesResponse(
 	return f
 }
 
-func (f *Follower) processCommand(command interface{}) (index int, term int) {
+func (f *Follower) processCommand(command interface{}) (index LogIndex, term Term) {
 	panic("Follower should not be processing commands!")
 }

--- a/src/raft/peer.go
+++ b/src/raft/peer.go
@@ -7,10 +7,10 @@ import (
 type Peer struct {
 	raft     *Raft
 	endPoint *labrpc.ClientEnd
-	serverId int
+	serverId ServerId
 }
 
-func (p *Peer) callRequestVote(term, candidate, lastLogIndex, lastLogTerm int) {
+func (p *Peer) callRequestVote(term Term, candidate ServerId, lastLogIndex LogIndex, lastLogTerm Term) {
 	args := &RequestVoteArgs{Term: term, CandidateId: candidate, LastLogIndex: lastLogIndex, LastLogTerm: lastLogTerm}
 	reply := &RequestVoteReply{}
 
@@ -23,7 +23,9 @@ func (p *Peer) callRequestVote(term, candidate, lastLogIndex, lastLogTerm int) {
 	p.raft.dispatchRequestVoteResponse(p, args, reply)
 }
 
-func (p *Peer) callAppendEntries(leaderId int, term int, prevLogIndex, prevLogTerm int, entries []*LogEntry, leaderCommit int) {
+func (p *Peer) callAppendEntries(leaderId ServerId, term Term, prevLogIndex LogIndex,
+	prevLogTerm Term, entries []*LogEntry, leaderCommit LogIndex) {
+
 	args := &AppendEntriesArgs{
 		LeaderId:     leaderId,
 		Term:         term,

--- a/src/raft/util.go
+++ b/src/raft/util.go
@@ -15,17 +15,17 @@ func init() {
 	log.SetFlags(log.Flags() | log.Lmicroseconds)
 }
 
-func DPrintf(procId int, topic string, format string, a ...interface{}) {
+func DPrintf(serverId ServerId, topic string, format string, a ...interface{}) {
 	if debug {
 		prefix := ""
 
-		prefix = prefix + fmt.Sprintf("[S%d][%v] S%d ", procId, string(topic), procId)
+		prefix = prefix + fmt.Sprintf("[S%d][%v] S%d ", serverId, string(topic), serverId)
 		format = prefix + format
 		log.Printf(format, a...)
 	}
 }
 
-func max(a, b int) int {
+func max(a, b LogIndex) LogIndex {
 	if a > b {
 		return a
 	} else {


### PR DESCRIPTION
1. Refactor server id, term and indexes to be separate types instead of all int
2. Change log to be 1-based and use position 0 for a sentinel log entry